### PR TITLE
WIP upgrades – very much not working yet!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 composer.lock
 composer.phar
 phpunit.xml
+.phpunit.result.cache
+
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: php
 
 php:
- - "5.6"
- - "7.0"
- - "7.1"
+ - "7.4"
+ - "8.0"
 
 before_script:
  - composer self-update
  - composer --version
  - composer install -n --dev --prefer-source
 
-script: vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpunit --coverage-text
+script: composer run lint:check && composer run test

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,27 @@
     "autoload": {
         "psr-4": { "GovTalk\\GiftAid\\" : "src/" }
     },
+    "config": {
+        "optimize-autoloader": true,
+        "platform": {
+            "php": "7.4.21"
+        },
+        "sort-packages": true
+    },
     "require": {
-        "php": ">=5.3.2",
-        "justinbusschau/php-govtalk": "~0.2.1"
+        "php": "^7.4 || ^8.0",
+        "ext-dom": "*",
+        "ext-xmlwriter": "*",
+        "justinbusschau/php-govtalk": "~0.2.1",
+        "guzzlehttp/guzzle": "^7.3.0"
     },
     "require-dev": {
-        "guzzle/plugin-mock": "~3.1",
-        "mockery/mockery": "~0.8",
-        "phpunit/phpunit": "~3.7.16",
-        "squizlabs/php_codesniffer": "~1.4"
+        "phpunit/phpunit": "^9.5.7",
+        "roave/security-advisories": "dev-master",
+        "squizlabs/php_codesniffer": "^3.6.0"
+    },
+    "scripts": {
+        "lint:check": "phpcs --standard=PSR2 src",
+        "test": "phpunit --coverage-text"
     }
 }

--- a/src/AuthorisedOfficial.php
+++ b/src/AuthorisedOfficial.php
@@ -11,8 +11,6 @@
 
 namespace GovTalk\GiftAid;
 
-use GovTalk\GiftAid\Individual;
-
 class AuthorisedOfficial extends Individual
 {
     public function __construct($title, $name, $surname, $phone, $postcode)

--- a/src/GiftAid.php
+++ b/src/GiftAid.php
@@ -11,12 +11,10 @@
 
 namespace GovTalk\GiftAid;
 
-use XMLWriter;
 use DOMDocument;
-use Guzzle\Http\ClientInterface;
+use GuzzleHttp\Client;
 use GovTalk\GovTalk;
-use GovTalk\GiftAid\Individual;
-use GovTalk\GiftAid\AuthorisedOfficial;
+use XMLWriter;
 
 /**
  * HMRC Gift Aid API client.  Extends the functionality provided by the
@@ -158,7 +156,7 @@ class GiftAid extends GovTalk
         $software_name,
         $software_version,
         $test = false,
-        ClientInterface $httpClient = null,
+        ?Client $httpClient = null,
         $messageLogLocation = null
     ) {
         $test = is_bool($test) ? $test : false;
@@ -774,7 +772,6 @@ class GiftAid extends GovTalk
                         'submission_request'  => $this->fullRequestString,
                         'submission_response' => $this->fullResponseString
                     );
-
                 } elseif ($messageQualifier == 'acknowledgement') {
                     $returnable                       = $this->getResponseEndpoint();
                     $returnable['correlationid']      = $this->getResponseCorrelationId();

--- a/tests/GovTalk/GiftAid/AuthorisedOfficialTest.php
+++ b/tests/GovTalk/GiftAid/AuthorisedOfficialTest.php
@@ -11,14 +11,12 @@
 
 namespace GovTalk\GiftAid;
 
-use GovTalk\GiftAid\TestCase;
-
 /**
  * The base class for all GovTalk\AuthorisedOfficial tests
  */
 class AuthorisedOfficialTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -30,7 +28,7 @@ class AuthorisedOfficialTest extends TestCase
             'SW1A 1AA'
         );
     }
-    
+
     public function testAuthorisedOfficialCreation()
     {
         $this->assertEquals($this->officer->getTitle(), 'Mr');
@@ -39,7 +37,7 @@ class AuthorisedOfficialTest extends TestCase
         $this->assertEquals($this->officer->getPhone(), '077 1234 5678');
         $this->assertEquals($this->officer->getPostcode(), 'SW1A 1AA');
     }
-    
+
     public function testUpdateAuthorisedOfficial()
     {
         $this->officer->setTitle('Mrs');
@@ -54,7 +52,7 @@ class AuthorisedOfficialTest extends TestCase
         $this->assertEquals($this->officer->getPhone(), '020 8765 4321');
         $this->assertEquals($this->officer->getPostcode(), 'NW1A 1AA');
     }
-    
+
     public function testHouseNumOmission()
     {
         $this->assertNull($this->officer->getHouseNum());

--- a/tests/GovTalk/GiftAid/ClaimingOrganisationTest.php
+++ b/tests/GovTalk/GiftAid/ClaimingOrganisationTest.php
@@ -11,14 +11,12 @@
 
 namespace GovTalk\GiftAid;
 
-use GovTalk\GiftAid\TestCase;
-
 /**
  * The base class for all GovTalk\ClaimingOrganisation tests
  */
 class ClaimingOrganisationTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -44,22 +42,22 @@ class ClaimingOrganisationTest extends TestCase
         $this->claimant->setHmrcRef('CD67890');
         $this->claimant->setRegulator('OSCR');
         $this->claimant->setRegNo('3695897469');
-        
+
         $this->assertEquals($this->claimant->getName(), 'Another Fine Bunch');
         $this->assertEquals($this->claimant->getHmrcRef(), 'CD67890');
         $this->assertEquals($this->claimant->getRegulator(), 'OSCR');
         $this->assertEquals($this->claimant->getRegNo(), '3695897469');
     }
-    
+
     public function testConnectedCharities()
     {
         $this->claimant->setHasConnectedCharities(true);
         $this->assertTrue($this->claimant->getHasConnectedCharities());
-        
+
         // non-bool values are treated as false
         $this->claimant->setHasConnectedCharities('0');
         $this->assertFalse($this->claimant->getHasConnectedCharities());
-        
+
         $org = new ClaimingOrganisation(
             'Giving Is Good',
             'EF24680',
@@ -68,19 +66,19 @@ class ClaimingOrganisationTest extends TestCase
         );
 
         $this->claimant->addConnectedCharity($org);
-        
+
         $org_a = $this->claimant->getConnectedCharities();
         $this->assertEquals(count($org_a), 1);
-        
+
         $org->setName('Greater Give');
         $org->setHmrcRef('GH13579');
         $org->setRegulator('OSCR');
         $org->setRegNo('6542147854');
         $this->claimant->addConnectedCharity($org);
-        
+
         $org_a = $this->claimant->getConnectedCharities();
         $this->assertEquals(count($org_a), 2);
-        
+
         $this->claimant->clearConnectedCharities();
         $org_a = $this->claimant->getConnectedCharities();
         $this->assertEquals(count($org_a), 0);

--- a/tests/GovTalk/GiftAid/GiftAidTest.php
+++ b/tests/GovTalk/GiftAid/GiftAidTest.php
@@ -11,8 +11,6 @@
 
 namespace GovTalk\GiftAid;
 
-use GovTalk\GiftAid\TestCase;
-
 /**
  * The base class for all GovTalk\GiftAid tests
  */
@@ -43,7 +41,7 @@ class GiftAidTest extends TestCase
      */
     private $gatewaySoftVersion;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -140,19 +138,6 @@ class GiftAidTest extends TestCase
          * Set parameter 5 to a valid path in order to log messages
          */
         $this->gaService = $this->setUpService();
-    }
-
-    private function setUpService()
-    {
-        return new GiftAid(
-            $this->gatewayUserID,
-            $this->gatewayUserPassword,
-            $this->gatewayVendorID,
-            $this->gatewaySoftware,
-            $this->gatewaySoftVersion,
-            true,
-            $this->getHttpClient()
-        );
     }
 
     public function testServiceCreation()
@@ -341,6 +326,8 @@ class GiftAidTest extends TestCase
     {
         $this->setMockHttpResponse('DeclarationResponsePoll.txt');
 
+
+
         $response = $this->gaService->declarationResponsePoll(
             'A19FA1A31BCB42D887EA323292AACD88',
             'https://secure.dev.gateway.gov.uk/poll'
@@ -375,5 +362,18 @@ class GiftAidTest extends TestCase
         );
 
         $this->assertTrue($response);
+    }
+
+    private function setUpService()
+    {
+        return new GiftAid(
+            $this->gatewayUserID,
+            $this->gatewayUserPassword,
+            $this->gatewayVendorID,
+            $this->gatewaySoftware,
+            $this->gatewaySoftVersion,
+            true,
+            $this->getHttpClient()
+        );
     }
 }

--- a/tests/GovTalk/GiftAid/IndividualTest.php
+++ b/tests/GovTalk/GiftAid/IndividualTest.php
@@ -11,14 +11,12 @@
 
 namespace GovTalk\GiftAid;
 
-use GovTalk\GiftAid\TestCase;
-
 /**
  * The base class for all GovTalk\GiftAid\Individual tests
  */
 class IndividualTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
See https://github.com/JustinBusschau/php-govtalk/pull/3 for a guide to
what some of the remaining changes will need to look like. To maintain
Guzzle library cross-compatability etc., another requirement for this
update will be for the upstream `php-govtalk` to be swapped over to its
v1.x (if updated in situ) or to the `thebiggive` fork.